### PR TITLE
ACR doesn't need annotation for arm

### DIFF
--- a/examples/multi-arch.yaml
+++ b/examples/multi-arch.yaml
@@ -18,9 +18,5 @@ steps:
     {{.Run.Registry}}/multi-arch:latest
     {{.Run.Registry}}/multi-arch:arm32
     {{.Run.Registry}}/multi-arch:amd64
-- cmd: >
-    docker manifest annotate 
-    {{.Run.Registry}}/multi-arch:latest 
-    {{.Run.Registry}}/multi-arch:arm32 --os linux --arch arm
 - cmd: docker manifest push --purge {{.Run.Registry}}/multi-arch:latest
 - cmd: docker manifest inspect {{.Run.Registry}}/multi-arch:latest


### PR DESCRIPTION
Annotation not required for multiarch for ACR. 
Docker for mac does require it though. 